### PR TITLE
Add dig2memory - code intelligence server using tree-sitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Tree-sitter is an incremental parsing system that produces concrete syntax trees
 - Analysis / navigation: https://github.com/microsoft/vscode-anycode — VS Code language features without servers.
 - Analysis / navigation: https://github.com/BloopAI/bloop/tree/main/server/bleep/src/intelligence — semantic search backed by Tree-sitter.
 - Analysis / navigation: https://github.com/bstee615/tree-climber — structural code analysis.
+- Analysis / navigation: https://github.com/ZENG3LD/dig2memory — code intelligence server using tree-sitter for multi-language AST indexing (Rust, TypeScript, Python, Go), caller tracking, dependency graphs, and impact analysis.
 - Analysis / navigation: https://github.com/zizmorcore/zizmor — static analysis via Tree-sitter.
 - Code highlighting: https://github.com/bearcove/arborium — Tree-sitter powered syntax colors.
 - Code manipulation: https://github.com/mizlan/iswap.nvim — swap nodes in NeoVim.


### PR DESCRIPTION
Adds [dig2memory](https://github.com/ZENG3LD/dig2memory) to the **Analysis / navigation** section of the Tools list.

dig2memory is a code intelligence server that uses tree-sitter for multi-language AST indexing (Rust, TypeScript, Python, Go). It exposes a REST API for fuzzy symbol search, caller tracking, dependency graphs, and impact analysis — designed to be consumed by AI agents and developer tooling.

Placed alphabetically after `tree-climber` and before `zizmor` within the existing Analysis / navigation group.